### PR TITLE
fix: blob deduplication logic using proper CID lookup

### DIFF
--- a/src/blobs/processor.ts
+++ b/src/blobs/processor.ts
@@ -104,11 +104,19 @@ export class BlobProcessor {
     postUri: string,
     ref: BlobReference
   ): Promise<void> {
-    const existing = await this.blobsRepo.findBySha256(ref.cid);
+    const existing = await this.blobsRepo.findByCid(ref.cid);
     if (existing) {
+      await this.blobsRepo.insert({
+        post_uri: postUri,
+        blob_cid: ref.cid,
+        sha256: existing.sha256,
+        phash: existing.phash,
+        storage_path: existing.storage_path,
+        mimetype: existing.mimetype,
+      });
       logger.debug(
         { postUri, cid: ref.cid },
-        "Blob already processed, skipping"
+        "Blob already processed, reusing hashes"
       );
       return;
     }

--- a/src/database/blobs.repository.ts
+++ b/src/database/blobs.repository.ts
@@ -103,4 +103,21 @@ export class BlobsRepository {
       );
     });
   }
+
+  async findByCid(cid: string): Promise<Blob | null> {
+    return new Promise((resolve, reject) => {
+      this.db.all(
+        `SELECT * FROM blobs WHERE blob_cid = $1 LIMIT 1`,
+        cid,
+        (err, rows: Blob[]) => {
+          if (err) {
+            logger.error({ err, cid }, "Failed to find blob by CID");
+            reject(err);
+            return;
+          }
+          resolve(rows?.[0] || null);
+        }
+      );
+    });
+  }
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -54,6 +54,7 @@ CREATE INDEX IF NOT EXISTS idx_labels_uri ON labels(uri);
 CREATE INDEX IF NOT EXISTS idx_labels_val ON labels(val);
 CREATE INDEX IF NOT EXISTS idx_labels_cts ON labels(cts);
 CREATE INDEX IF NOT EXISTS idx_posts_did ON posts(did);
+CREATE INDEX IF NOT EXISTS idx_blobs_cid ON blobs(blob_cid);
 CREATE INDEX IF NOT EXISTS idx_blobs_sha256 ON blobs(sha256);
 CREATE INDEX IF NOT EXISTS idx_blobs_phash ON blobs(phash);
 `;

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -175,5 +175,11 @@ describe("Database Integration Tests", () => {
       const found = await blobsRepo.findByPhash("deadbeef");
       expect(found.length).toBeGreaterThan(0);
     });
+
+    test("should find blob by CID", async () => {
+      const found = await blobsRepo.findByCid("bafytest123");
+      expect(found).not.toBeNull();
+      expect(found?.sha256).toBe("abc123def456");
+    });
   });
 });


### PR DESCRIPTION
The blob processor was using `findBySha256(ref.cid)` which incorrectly passed a CID to a method expecting a SHA256 hash. This caused the deduplication check to never find matches, resulting in blobs being unnecessarily reprocessed regardless of the hydrate_blobs setting.

Changes:
- Add `findByCid` method to BlobsRepository for proper CID lookup
- Update processor to use CID-based deduplication
- When blob exists, reuse hashes but still insert post+blob relationship
- Add index on blob_cid column for query performance
- Add test coverage for new findByCid method

🤖 Generated with [Claude Code](https://claude.com/claude-code)